### PR TITLE
Implement basic DM group creation

### DIFF
--- a/templates/chat.html
+++ b/templates/chat.html
@@ -1,0 +1,14 @@
+{% extends 'base.html' %}
+{% block content %}
+  <h2>DM</h2>
+  <ul>
+  {% for m in messages %}
+    <li>{{ m.user.username }}: {{ m.content }} ({{ m.timestamp }})</li>
+  {% endfor %}
+  </ul>
+  <form method="post">
+    {{ form.hidden_tag() }}
+    <p>{{ form.message.label }}<br>{{ form.message() }}</p>
+    <p>{{ form.submit() }}</p>
+  </form>
+{% endblock %}

--- a/templates/matches.html
+++ b/templates/matches.html
@@ -7,6 +7,7 @@
       <li>
         {{ r.start }} - {{ r.end }} ({{ r.hours|round(2) }}h) -
         {{ r.friend.username }}さんと「{{ r.category }}」
+        <a href="{{ url_for('chat', room_id=r.room_id) }}">DM</a>
       </li>
     {% endfor %}
     </ul>


### PR DESCRIPTION
## Summary
- add ChatRoom and ChatMessage models and a form for chatting
- create DM rooms when a valid match is detected
- link to each DM from the match list
- add page to send and view messages in a room

## Testing
- `python -m py_compile app.py`
- `python app.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68421085151083209a664374e6caf706