### PR TITLE
Fix missing matches due to default participant counts

### DIFF
--- a/app.py
+++ b/app.py
@@ -184,14 +184,22 @@ def init_db():
         cols = [row[1] for row in db.session.execute("PRAGMA table_info('match_request')")]
         if 'min_people' not in cols:
             db.session.execute(
-                "ALTER TABLE match_request ADD COLUMN min_people INTEGER NOT NULL DEFAULT 1"
+                "ALTER TABLE match_request ADD COLUMN min_people INTEGER NOT NULL DEFAULT 2"
             )
             db.session.commit()
+        db.session.execute(
+            "UPDATE match_request SET min_people = 2 WHERE min_people IS NULL OR min_people < 2"
+        )
+        db.session.commit()
         if 'max_people' not in cols:
             db.session.execute(
-                "ALTER TABLE match_request ADD COLUMN max_people INTEGER NOT NULL DEFAULT 1"
+                "ALTER TABLE match_request ADD COLUMN max_people INTEGER NOT NULL DEFAULT 2"
             )
             db.session.commit()
+        db.session.execute(
+            "UPDATE match_request SET max_people = 2 WHERE max_people IS NULL OR max_people < 2"
+        )
+        db.session.commit()
     except Exception:
         pass
 


### PR DESCRIPTION
## Summary
- use 2 as the default value when adding `min_people` and `max_people`
- backfill existing `match_request` rows so participant counts below 2 become 2

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_68427fae30c883209d9efd7121c9f088